### PR TITLE
Remove collections requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/support": "~5.2",
         "nesbot/carbon": "^1.22"
     },
     "autoload": {
@@ -34,6 +33,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "~3.2",
-        "phpunit/phpunit": "^6.1"
+        "phpunit/phpunit": "^6.1",
+        "illuminate/support": "~5.2"
     }
 }

--- a/src/FeedItem.php
+++ b/src/FeedItem.php
@@ -59,13 +59,15 @@ class FeedItem
     public function build()
     {
         return array_filter(
-            $this->collapse(array_map(function ($property) {
-                $method = 'get' . studly_case($property);
+            $this->collapse(
+                array_map(function ($property) {
+                    $method = 'get' . studly_case($property);
 
-                return [
-                    $property => $this->$method(),
-                ];
-            }, $this->acceptedProperties))
+                    return [
+                        $property => $this->$method(),
+                    ];
+                }, $this->acceptedProperties)
+            )
         );
     }
 

--- a/src/JsonFeed.php
+++ b/src/JsonFeed.php
@@ -6,9 +6,12 @@ use BadMethodCallException;
 use Illuminate\Support\Collection;
 use Mateusjatenee\JsonFeed\Exceptions\IncorrectFeedStructureException;
 use Mateusjatenee\JsonFeed\FeedItem;
+use Mateusjatenee\JsonFeed\Traits\ArrayHelpers;
 
 class JsonFeed
 {
+    use ArrayHelpers;
+
     /**
      * @var array
      */
@@ -192,15 +195,6 @@ class JsonFeed
     public function getVersion()
     {
         return $this->version;
-    }
-
-    /**
-     * @param $items
-     * @return mixed
-     */
-    protected function makeArray($items)
-    {
-        return $items instanceof Collection ? $items->toArray() : $items;
     }
 
     /**

--- a/src/JsonFeed.php
+++ b/src/JsonFeed.php
@@ -73,16 +73,14 @@ class JsonFeed
         if (!$this->hasCorrectStructure()) {
             $missingProperties = array_diff(
                 $this->requiredProperties,
-                $this->filterProperties($this->requiredProperties)->keys()->all()
+                array_keys($this->filterProperties($this->requiredProperties))
             );
 
             throw (new IncorrectFeedStructureException)->setProperties($missingProperties);
         }
 
         return $this
-            ->filterProperties()
-            ->put('version', $this->getVersion())
-            ->put('items', $this->buildItems()->all());
+            ->filterProperties() + ['version' => $this->getVersion(), 'items' => $this->buildItems()];
     }
 
     /**
@@ -92,12 +90,12 @@ class JsonFeed
      */
     public function toArray()
     {
-        return $this->build()->toArray();
+        return $this->build();
     }
 
     public function toJson()
     {
-        return $this->build()->toJson();
+        return json_encode($this->build());
     }
 
     /**
@@ -118,7 +116,7 @@ class JsonFeed
      */
     public function setItems($items)
     {
-        $this->items = $this->makeCollection($items);
+        $this->items = $this->makeArray($items);
 
         return $this;
     }
@@ -139,7 +137,7 @@ class JsonFeed
      */
     public function setConfig($config)
     {
-        $this->properties = $this->makeCollection($config);
+        $this->properties = $this->makeArray($config);
 
         return $this;
     }
@@ -161,7 +159,7 @@ class JsonFeed
      */
     protected function hasCorrectStructure()
     {
-        return $this->filterProperties($this->requiredProperties)->count() === count($this->requiredProperties);
+        return count($this->filterProperties($this->requiredProperties)) === count($this->requiredProperties);
     }
 
     /**
@@ -172,7 +170,7 @@ class JsonFeed
      */
     protected function filterProperties($array = null)
     {
-        return $this->properties->intersectByKeys(array_flip($array ?? $this->acceptedProperties));
+        return array_intersect_key($this->properties, array_flip($array ?? $this->acceptedProperties));
     }
 
     /**
@@ -183,7 +181,7 @@ class JsonFeed
      */
     protected function getProperty($property)
     {
-        return $this->properties->get($property);
+        return $this->properties[$property] ?? null;
     }
 
     /**
@@ -210,9 +208,9 @@ class JsonFeed
      */
     protected function buildItems()
     {
-        return $this->items->map(function ($item) {
+        return array_map(function ($item) {
             return FeedItem::setItem($item)->toArray();
-        });
+        }, $this->items);
     }
 
     /**

--- a/src/JsonFeed.php
+++ b/src/JsonFeed.php
@@ -47,8 +47,8 @@ class JsonFeed
      */
     public function __construct($properties = [], $items = [])
     {
-        $this->properties = $this->makeCollection($properties);
-        $this->items = $this->makeCollection($items);
+        $this->properties = $this->makeArray($properties);
+        $this->items = $this->makeArray($items);
     }
 
     /**
@@ -200,9 +200,9 @@ class JsonFeed
      * @param $items
      * @return mixed
      */
-    protected function makeCollection($items)
+    protected function makeArray($items)
     {
-        return $items instanceof Collection ? $items : new Collection($items);
+        return $items instanceof Collection ? $items->toArray() : $items;
     }
 
     /**

--- a/src/JsonFeedServiceProvider.php
+++ b/src/JsonFeedServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Mateusjatenee\JsonFeed;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Mateusjatenee\JsonFeed\JsonFeed;
 
@@ -21,10 +20,6 @@ class JsonFeedServiceProvider extends ServiceProvider
 
         $this->app->singleton('jsonFeed', function ($app) use ($config) {
             return new JsonFeed($config);
-        });
-
-        Collection::macro('intersectByKeys', function ($array) {
-            return new static(array_intersect_key($this->items, $array));
         });
     }
 }

--- a/src/Traits/ArrayHelpers.php
+++ b/src/Traits/ArrayHelpers.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Mateusjatenee\JsonFeed\Traits;
+
+use Illuminate\Support\Collection;
+
+trait ArrayHelpers
+{
+    /**
+     * @param $items
+     * @return mixed
+     */
+    protected function makeArray($items)
+    {
+        return $items instanceof Collection ? $items->toArray() : $items;
+    }
+
+    /**
+     * Collapse an array of arrays into a single array.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    protected function collapse($array)
+    {
+        $results = [];
+
+        foreach ($array as $values) {
+            if ($values instanceof Collection) {
+                $values = $values->all();
+            } elseif (!is_array($values)) {
+                continue;
+            }
+
+            $results = array_merge($results, $values);
+        }
+
+        return $results;
+    }
+}

--- a/tests/JsonFeedTest.php
+++ b/tests/JsonFeedTest.php
@@ -80,10 +80,12 @@ class JsonFeedTest extends TestCase
     }
 
     /** @test */
-    public function it_automatically_converts_an_array_to_a_collection()
+    public function it_automatically_converts_a_collection_to_array()
     {
-        $feed = JsonFeed::start([], [new DummyFeedItem]);
-        $this->assertInstanceOf(Collection::class, $feed->getItems());
+        $feed = JsonFeed::start(new Collection([]), new Collection([new DummyFeedItem]));
+
+        $this->assertInternalType('array', $feed->getItems());
+        $this->assertInternalType('array', $feed->getConfig());
     }
 
     /** @test */

--- a/tests/JsonFeedTest.php
+++ b/tests/JsonFeedTest.php
@@ -93,8 +93,7 @@ class JsonFeedTest extends TestCase
     {
         $feed = JsonFeed::start([], collect([new DummyFeedItem]));
 
-        $this->assertInstanceOf(Collection::class, $feed->getItems());
-        $this->assertInstanceOf(DummyFeedItem::class, $feed->getItems()->first());
+        $this->assertInstanceOf(DummyFeedItem::class, $feed->getItems()[0]);
     }
 
     /** @test */
@@ -102,7 +101,7 @@ class JsonFeedTest extends TestCase
     {
         $feed = app('jsonFeed')->setConfig($config = $this->getJsonFeedConfig());
 
-        $this->assertEquals(count($config), $feed->getConfig()->count());
+        $this->assertEquals(count($config), count($feed->getConfig()));
     }
 
     /** @test */
@@ -110,7 +109,7 @@ class JsonFeedTest extends TestCase
     {
         $feed = app('jsonFeed')->setItems($items = $this->getArrayOfItems());
 
-        $this->assertEquals(count($items), $feed->getItems()->count());
+        $this->assertEquals(count($items), count($feed->getItems()));
     }
 
     /** @test */


### PR DESCRIPTION
Removes the necessity of collections. Keeps it on `require-dev` to test it can automatically be converted to an array