### PR TITLE
Modified readme file for laravel 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ $ composer require mateusjatenee/php-json-feed
 
 #### Laravel Installation   
 
-On your `config/app.php` file, register the service provider:   
+If you are using __laravel 5.5__ or higher the installation is already finished! You don't need to do another thing.
+
+If you are using laravel 5.4 or lower open your `config/app.php` file and register the service provider:   
 ```php   
 'providers' => [
     ...


### PR DESCRIPTION
I have modified the readme file to fit the installation on laravel 5.5.

When I tried to install the package I was confused I had to register the service provider manually.. so I looked it up in the `composer.json` file and saw, that it already has laravel 5.5 auto-package-discovery.

So I simply modified the readme file.

I haven't created a feature branch because it isn't a feature.. If you want I can create a new branch and resend the PR.

Have a nice day,
Jordan